### PR TITLE
F7 usb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,7 @@ PREFIX		?= arm-none-eabi-
 STYLECHECK      := scripts/checkpatch.pl
 STYLECHECKFLAGS := --no-tree -f --terse --mailback
 
-TARGETS ?=	stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/f7 \
-		stm32/l0 stm32/l1 stm32/l4 \
-		stm32/g0 \
-		stm32/h7 \
-		gd32/f1x0 \
-		lpc13xx lpc17xx lpc43xx/m4 lpc43xx/m0 \
-		lm3s lm4f msp432/e4 \
-		efm32/tg efm32/g efm32/lg efm32/gg efm32/hg efm32/wg \
-		efm32/ezr32wg \
-		sam/3a sam/3n sam/3s sam/3u sam/3x sam/4l \
-		sam/d \
-		vf6xx \
-		swm050 \
-		pac55xx
+TARGETS ?=	stm32/f7 
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)

--- a/include/libopencm3/usb/dwc/otg_fs.h
+++ b/include/libopencm3/usb/dwc/otg_fs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_FS_BASE address */
-#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F1) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
 #	include <libopencm3/stm32/memorymap.h>
 #elif defined(EFM32HG)
 #	include <libopencm3/efm32/memorymap.h>

--- a/include/libopencm3/usb/dwc/otg_hs.h
+++ b/include/libopencm3/usb/dwc/otg_hs.h
@@ -28,7 +28,7 @@
 #include <libopencm3/usb/dwc/otg_common.h>
 
 /* Memory map is required for USB_OTG_HS_BASE address */
-#if defined(STM32F2) || defined(STM32F4)
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
 #	include <libopencm3/stm32/memorymap.h>
 #else
 #	error "device family not supported by dwc/otg_hs."

--- a/lib/Makefile.include
+++ b/lib/Makefile.include
@@ -28,7 +28,7 @@ OBJS += vector.o systick.o scb.o nvic.o assert.o sync.o dwt.o
 
 # Slightly bigger .elf files but gains the ability to decode macros
 DEBUG_FLAGS ?= -ggdb3
-STANDARD_FLAGS ?= -std=c99
+STANDARD_FLAGS ?= -std=c11
 
 all: $(SRCLIBDIR)/$(LIBNAME).a
 

--- a/lib/stm32/f7/Makefile
+++ b/lib/stm32/f7/Makefile
@@ -63,6 +63,9 @@ OBJS += spi_common_all.o spi_common_v2.o
 OBJS += timer_common_all.o
 OBJS += usart_common_all.o usart_common_v2.o
 
+OBJS += usb.o usb_standard.o usb_control.o usb_dwc_common.o \
+        usb_f107.o usb_f207.o usb_msc.o
+
 # Ethernet
 OBJS += mac.o phy.o mac_stm32fxx7.o phy_ksz80x1.o
 


### PR DESCRIPTION
Some minor updates to the library code to enable USB with the F7 chip.

Majority of these changes are based on https://github.com/libopencm3/libopencm3/pull/958

Additional changes may be necessary to get USB working.