### PR TITLE
F7 RTC support

### DIFF
--- a/include/libopencm3/stm32/f7/rtc.h
+++ b/include/libopencm3/stm32/f7/rtc.h
@@ -1,12 +1,12 @@
 /** @defgroup rtc_defines RTC Defines
 
-@brief <b>Defined Constants and Types for the STM32F7xxx RTC</b>
+@brief <b>Defined Constants and Types for the STM32F4xx RTC</b>
 
-@ingroup STM32F7xxx_defines
+@ingroup STM32F4xx_defines
 
 @version 1.0.0
 
-@date 26 March 2020
+@date 5 December 2012
 
 LGPL License Terms @ref lgpl_license
  */

--- a/include/libopencm3/stm32/rtc.h
+++ b/include/libopencm3/stm32/rtc.h
@@ -28,6 +28,8 @@
 #       include <libopencm3/stm32/f2/rtc.h>
 #elif defined(STM32F4)
 #       include <libopencm3/stm32/f4/rtc.h>
+#elif defined(STM32F7)
+#       include <libopencm3/stm32/f7/rtc.h>
 #elif defined(STM32L0)
 #       include <libopencm3/stm32/l0/rtc.h>
 #elif defined(STM32L1)


### PR DESCRIPTION
Adding basic support for the RTC peripheral. Currently libopencm3 does not have the peripheral libraries set up for F7, even though it is an included peripheral.